### PR TITLE
fix: link to manual, resolves #301

### DIFF
--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -53,7 +53,11 @@ const BaseCard = ({
               <span className="mx-2">&ndash;</span>
             </>
           )}
-          <Link to="/manual.pdf" reloadDocument className="text-blue-500 hover:underline">
+          <Link
+            to="/manual.pdf"
+            reloadDocument
+            className="text-blue-500 hover:underline"
+          >
             Manual
           </Link>
           <span className="mx-2">&ndash;</span>

--- a/frontend/src/components/BaseCard.js
+++ b/frontend/src/components/BaseCard.js
@@ -53,7 +53,7 @@ const BaseCard = ({
               <span className="mx-2">&ndash;</span>
             </>
           )}
-          <Link to="/manual.pdf" className="text-blue-500 hover:underline">
+          <Link to="/manual.pdf" reloadDocument className="text-blue-500 hover:underline">
             Manual
           </Link>
           <span className="mx-2">&ndash;</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `BaseCard` component with a `reloadDocument` attribute for the manual PDF link, allowing the document to reload upon clicking. 

- **Bug Fixes**
	- Improved link behavior to ensure proper document reloading instead of navigating within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->