### PR TITLE
fix: switch to multiarch build again

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -22,11 +22,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        platform: [linux/amd64, linux/arm64]
 
     steps:
       - name: Checkout repository
@@ -38,6 +33,9 @@ jobs:
         uses: sigstore/cosign-installer@v3
         with:
           cosign-release: "v2.4.1"
+
+      - name: Setup QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -76,7 +74,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64 
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64 
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  - Docker images now support multiple architectures, enhancing compatibility and deployment flexibility across different platforms.

- **Chores**  
  - The image publishing workflow has been streamlined for a smoother, more efficient multi-architecture build process, ensuring a more reliable deployment experience for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->