### PR TITLE
fix: update runtime image to install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ WORKDIR /app
 VOLUME [ "/app/data" ]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-RUN useradd -m -s /bin/bash appuser
+    useradd -m -s /bin/bash appuser && \
+    rm -rf /var/lib/apt/lists/* 
 
 # Copy frontend build
 COPY --from=backend-build /app/backend/kasseapparat ./kasseapparat

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN CGO_ENABLED=1 go build -o kasseapparat ./cmd/main.go && \
 FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS runtime
 WORKDIR /app
 VOLUME [ "/app/data" ]
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 RUN useradd -m -s /bin/bash appuser
 
 # Copy frontend build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Ensured SSL certificates are included in the runtime image for improved compatibility with secure connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->