### PR TITLE
fix: update Cosign image signing command to use the correct image ref…

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -110,6 +110,6 @@ jobs:
 
       - name: Sign image with Cosign
         run: |
-          cosign sign --yes ${{ steps.meta.outputs.tags }}
+          cosign sign --yes ghcr.io/${{ github.repository }}@${{ steps.build-and-push.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: "1"


### PR DESCRIPTION
…erence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the image signing process in the build workflow to use the image's digest instead of its tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->