### PR TITLE
feat: optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=frontend-build /app/frontend/build ./cmd/assets
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=1 go build -o kasseapparat ./cmd/main.go && \
     CGO_ENABLED=1 go build -o kasseapparat-tool ./tools/main.go
+RUN strip kasseapparat-tool && \
+    strip kasseapparat
 
 # Create the final image
 FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS runtime


### PR DESCRIPTION
This pull request introduces improvements to the `Dockerfile` for better performance during builds. Key changes include the use of build cache mounts to optimize dependency installation, the addition of binary stripping to reduce image size, and improved file ownership handling.

💾 This effectively reduces image size from 228MB to 136MB (40% reduction).

### Build optimization:
* Added build cache mounts for `yarn` cache (`frontend/.yarn/cache`), `apt` cache (`/var/cache/apt` and `/var/lib/apt`), Go modules (`/go/pkg/mod`), and Go build cache (`/root/.cache/go-build`) to speed up dependency installation and builds. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R33) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L34-R56)

### Image size reduction:
* Added `strip` commands to remove debugging symbols from `kasseapparat` and `kasseapparat-tool` binaries, reducing the final image size. (about 10MB saved per executable)
* Used `COPY --chown` to ensure proper ownership of copied files by `appuser`. By not modifying the file after its copy, we preserve a unique copy, otherwise the file was being **duplicated** twice in image (due to `chmod` and `chown`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker image build performance through enhanced caching for dependencies and build artifacts.
  - Reduced backend binary size in the final image.
  - Streamlined user and file ownership setup during image build.
  - Updated Dockerfile syntax for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->