### PR TITLE
fix: Avoid passing JWT token in WebSocket URL, resolves #519

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -32,6 +32,7 @@ func main() {
 	sqliteRepository := sqliteRepo.NewRepository(db, int32(cfg.FormatConfig.FractionDigitsMax))
 	sumupRepository := sumupRepo.NewRepository(initializer.GetSumupService())
 	mailer := initializer.InitializeMailer(cfg.MailerConfig)
+	jwtMiddleware := initializer.InitializeJwtMiddleware(sqliteRepository, cfg.JwtConfig)
 
 	purchaseService := purchaseService.NewPurchaseService(sqliteRepository, sumupRepository, &mailer, int32(cfg.FormatConfig.FractionDigitsMax))
 
@@ -47,10 +48,11 @@ func main() {
 		StatusPublisher: publisher,
 		Mailer:          mailer,
 		AppConfig:       cfg,
+		JwtMiddleware:   jwtMiddleware,
 	}
 	httpHandler := handlerHttp.NewHandler(httpHandlerConfig)
 
-	router := initializer.InitializeHttpServer(*httpHandler, websocketHandler, *sqliteRepository, staticFiles, cfg)
+	router := initializer.InitializeHttpServer(*httpHandler, websocketHandler, *sqliteRepository, staticFiles, jwtMiddleware, cfg)
 
 	startPollerForPendingPurchases(poller, sqliteRepository)
 

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	purchaseService := purchaseService.NewPurchaseService(sqliteRepository, sumupRepository, &mailer, int32(cfg.FormatConfig.FractionDigitsMax))
 
-	websocketHandler := websocket.NewHandler(sqliteRepository, sumupRepository, purchaseService, &cfg.CorsAllowOrigins)
+	websocketHandler := websocket.NewHandler(sqliteRepository, sumupRepository, purchaseService, jwtMiddleware, &cfg.CorsAllowOrigins)
 	publisher := &websocket.WebsocketPublisher{}
 	poller := monitor.NewPoller(sumupRepository, sqliteRepository, purchaseService, publisher)
 
@@ -48,7 +48,6 @@ func main() {
 		StatusPublisher: publisher,
 		Mailer:          mailer,
 		AppConfig:       cfg,
-		JwtMiddleware:   jwtMiddleware,
 	}
 	httpHandler := handlerHttp.NewHandler(httpHandlerConfig)
 

--- a/backend/internal/app/handler/http/handler.go
+++ b/backend/internal/app/handler/http/handler.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/google/uuid"
 	"github.com/potibm/kasseapparat/internal/app/config"
 	"github.com/potibm/kasseapparat/internal/app/mailer"
@@ -25,7 +24,6 @@ type Handler struct {
 	mailer          mailer.Mailer
 	config          config.Config
 	decimalPlaces   int32
-	jwtMiddleware   *jwt.GinJWTMiddleware
 }
 
 type HandlerConfig struct {
@@ -36,7 +34,6 @@ type HandlerConfig struct {
 	StatusPublisher StatusPublisher
 	Mailer          mailer.Mailer
 	AppConfig       config.Config
-	JwtMiddleware   *jwt.GinJWTMiddleware
 }
 
 func NewHandler(config HandlerConfig) *Handler {
@@ -49,6 +46,5 @@ func NewHandler(config HandlerConfig) *Handler {
 		mailer:          config.Mailer,
 		config:          config.AppConfig,
 		decimalPlaces:   int32(config.AppConfig.FormatConfig.FractionDigitsMax),
-		jwtMiddleware:   config.JwtMiddleware,
 	}
 }

--- a/backend/internal/app/handler/http/handler.go
+++ b/backend/internal/app/handler/http/handler.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/google/uuid"
 	"github.com/potibm/kasseapparat/internal/app/config"
 	"github.com/potibm/kasseapparat/internal/app/mailer"
@@ -24,6 +25,7 @@ type Handler struct {
 	mailer          mailer.Mailer
 	config          config.Config
 	decimalPlaces   int32
+	jwtMiddleware   *jwt.GinJWTMiddleware
 }
 
 type HandlerConfig struct {
@@ -34,6 +36,7 @@ type HandlerConfig struct {
 	StatusPublisher StatusPublisher
 	Mailer          mailer.Mailer
 	AppConfig       config.Config
+	JwtMiddleware   *jwt.GinJWTMiddleware
 }
 
 func NewHandler(config HandlerConfig) *Handler {
@@ -46,5 +49,6 @@ func NewHandler(config HandlerConfig) *Handler {
 		mailer:          config.Mailer,
 		config:          config.AppConfig,
 		decimalPlaces:   int32(config.AppConfig.FormatConfig.FractionDigitsMax),
+		jwtMiddleware:   config.JwtMiddleware,
 	}
 }

--- a/backend/internal/app/handler/websocket/handler.go
+++ b/backend/internal/app/handler/websocket/handler.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 
+	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -34,18 +35,19 @@ type Handler struct {
 	sqliteRepository sqliteRepository
 	purchaseService  purchaseService.Service
 	upgrader         websocket.Upgrader
+	jwtMiddleware    *jwt.GinJWTMiddleware
 }
 
 type sqliteRepository interface {
 	GetPurchaseByID(id uuid.UUID) (*models.Purchase, error)
 }
 
-func NewHandler(sqliteRepository sqliteRepository, sumupRepository sumupRepo.RepositoryInterface, purchaseService purchaseService.Service, corsAllowOrigins *config.CorsAllowOriginsConfig) *Handler {
+func NewHandler(sqliteRepository sqliteRepository, sumupRepository sumupRepo.RepositoryInterface, purchaseService purchaseService.Service, jwtMiddleware *jwt.GinJWTMiddleware, corsAllowOrigins *config.CorsAllowOriginsConfig) *Handler {
 	upgrader := websocket.Upgrader{
 		CheckOrigin: makeCheckOrigin(corsAllowOrigins),
 	}
 
-	return &Handler{sqliteRepository: sqliteRepository, sumupRepository: sumupRepository, purchaseService: purchaseService, upgrader: upgrader}
+	return &Handler{sqliteRepository: sqliteRepository, sumupRepository: sumupRepository, purchaseService: purchaseService, upgrader: upgrader, jwtMiddleware: jwtMiddleware}
 }
 
 func makeCheckOrigin(allowedOrigins *config.CorsAllowOriginsConfig) func(r *http.Request) bool {

--- a/backend/internal/app/handler/websocket/purchases.go
+++ b/backend/internal/app/handler/websocket/purchases.go
@@ -18,7 +18,6 @@ func (h *Handler) HandleTransactionWebSocket(c *gin.Context) {
 	}
 
 	tokenStr := protocols[0]
-	log.Println("WebSocket connection attempt with token:", tokenStr)
 
 	token, err := h.jwtMiddleware.ParseTokenString(tokenStr)
 	if err != nil {

--- a/backend/internal/app/handler/websocket/purchases.go
+++ b/backend/internal/app/handler/websocket/purchases.go
@@ -10,6 +10,15 @@ import (
 )
 
 func (h *Handler) HandleTransactionWebSocket(c *gin.Context) {
+	protocols := websocket.Subprotocols(c.Request)
+	if len(protocols) == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing token"})
+		return
+	}
+
+	tokenStr := protocols[0]
+	log.Println("WebSocket connection attempt with token:", tokenStr)
+
 	transactionID, conn, ok := h.upgradeAndRegister(c)
 	if !ok {
 		return

--- a/backend/internal/app/initializer/http_server.go
+++ b/backend/internal/app/initializer/http_server.go
@@ -125,6 +125,8 @@ func registerApiRoutes(httpHandler httpHandler.Handler, websockeHandler websocke
 		unprotectedApiRouter.POST("/auth/changePassword", httpHandler.UpdateUserPassword)
 
 		unprotectedApiRouter.POST("/sumup/webhook", httpHandler.GetSumupTransactionWebhook)
+
+		unprotectedApiRouter.GET("/purchases/:id/ws", websockeHandler.HandleTransactionWebSocket)
 	}
 }
 
@@ -171,7 +173,6 @@ func registerPurchaseRoutes(rg *gin.RouterGroup, handler httpHandler.Handler, we
 		purchases.DELETE("/:id", handler.DeletePurchase)
 		purchases.GET("/export", handler.ExportPurchases)
 		purchases.POST("/:id/refund", handler.RefundPurchase)
-		purchases.GET("/:id/ws", websockeHandler.HandleTransactionWebSocket)
 	}
 }
 

--- a/backend/internal/app/initializer/jwt_middleware.go
+++ b/backend/internal/app/initializer/jwt_middleware.go
@@ -8,7 +8,9 @@ import (
 )
 
 func InitializeJwtMiddleware(repository *sqliteRepo.Repository, jwtConfig config.JwtConfig) *jwt.GinJWTMiddleware {
-	jwtMiddleware, err := jwt.New(middleware.InitParams(repository, jwtConfig.Realm, jwtConfig.Secret, 10))
+	const timeout = 10 // Duration that a jwt token is valid, in minutes
+
+	jwtMiddleware, err := jwt.New(middleware.InitParams(repository, jwtConfig.Realm, jwtConfig.Secret, timeout))
 	if err != nil {
 		panic("[Error] failed to initialize JWT middleware: " + err.Error())
 	}

--- a/backend/internal/app/initializer/jwt_middleware.go
+++ b/backend/internal/app/initializer/jwt_middleware.go
@@ -1,0 +1,17 @@
+package initializer
+
+import (
+	jwt "github.com/appleboy/gin-jwt/v2"
+	"github.com/potibm/kasseapparat/internal/app/config"
+	"github.com/potibm/kasseapparat/internal/app/middleware"
+	sqliteRepo "github.com/potibm/kasseapparat/internal/app/repository/sqlite"
+)
+
+func InitializeJwtMiddleware(repository *sqliteRepo.Repository, jwtConfig config.JwtConfig) *jwt.GinJWTMiddleware {
+	jwtMiddleware, err := jwt.New(middleware.InitParams(repository, jwtConfig.Realm, jwtConfig.Secret, 10))
+	if err != nil {
+		panic("[Error] failed to initialize JWT middleware: " + err.Error())
+	}
+
+	return jwtMiddleware
+}

--- a/backend/internal/app/middleware/auth.go
+++ b/backend/internal/app/middleware/auth.go
@@ -44,7 +44,7 @@ func RegisterRoute(r *gin.Engine, handle *ginjwt.GinJWTMiddleware) {
 	auth.GET("/refresh_token", handle.RefreshHandler)
 }
 
-func InitParams(repo sqliteRepo.Repository, realm string, secret string, timeout int) *ginjwt.GinJWTMiddleware {
+func InitParams(repo *sqliteRepo.Repository, realm string, secret string, timeout int) *ginjwt.GinJWTMiddleware {
 	if secret == "" {
 		log.Println("JWT_SECRET is not set, using default value")
 
@@ -60,7 +60,7 @@ func InitParams(repo sqliteRepo.Repository, realm string, secret string, timeout
 		PayloadFunc: payloadFunc(),
 
 		IdentityHandler: identityHandler(),
-		Authenticator:   authenticator(&repo),
+		Authenticator:   authenticator(repo),
 		Authorizator:    authorizator(),
 		Unauthorized:    unauthorized(),
 		TokenLookup:     "header: Authorization, query: token, cookie: jwt",

--- a/backend/tests/e2e/init_test.go
+++ b/backend/tests/e2e/init_test.go
@@ -91,10 +91,9 @@ func setupTestEnvironment(t *testing.T) (*httptest.Server, func()) {
 		Monitor:         poller,
 		Mailer:          *mailer,
 		AppConfig:       cfg,
-		JwtMiddleware:   jwtMiddleware,
 	}
 	handlerHttp := handlerHttp.NewHandler(httpHandlerConfig)
-	websocketHandler := websocket.NewHandler(sqliteRepo, sumupRepo, purchaseService, &cfg.CorsAllowOrigins)
+	websocketHandler := websocket.NewHandler(sqliteRepo, sumupRepo, purchaseService, jwtMiddleware, &cfg.CorsAllowOrigins)
 
 	router := initializer.InitializeHttpServer(*handlerHttp, websocketHandler, *sqliteRepo, embed.FS{}, jwtMiddleware, cfg)
 

--- a/backend/tests/e2e/purchase_ws_test.go
+++ b/backend/tests/e2e/purchase_ws_test.go
@@ -36,7 +36,7 @@ func TestGetPurchaseWebsocketWithInvalidOrigin(t *testing.T) {
 	conn, resp, err := connectWS(t, wsURL, token, "http://example.com:3000")
 	require.Error(t, err)
 	require.NotNil(t, resp)
-	require.Equal(t, http.StatusForbidden, resp.StatusCode) // oder 400, je nach Upgrader-Fehler
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	if conn != nil {
 		conn.Close()

--- a/backend/tests/e2e/purchase_ws_test.go
+++ b/backend/tests/e2e/purchase_ws_test.go
@@ -1,0 +1,73 @@
+package tests_e2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPurchaseWebsocketWithInvalidToken(t *testing.T) {
+	ts, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/v2/purchases/123/ws"
+
+	// no token provided
+	_, resp, err := connectWS(t, wsURL, "", "http://localhost:3000")
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// with invalid token
+	_, resp, err = connectWS(t, wsURL, "invalid.token.here", "http://localhost:3000")
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestGetPurchaseWebsocketWithInvalidOrigin(t *testing.T) {
+	ts, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/v2/purchases/01982971-a954-74ed-9735-a75e08efa8f6/ws"
+	token := getJwtForDemoUser()
+
+	conn, resp, err := connectWS(t, wsURL, token, "http://example.com:3000")
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode) // oder 400, je nach Upgrader-Fehler
+
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+func TestGetPurchaseWebsocketWithValidToken(t *testing.T) {
+	ts, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/v2/purchases/01982971-a954-74ed-9735-a75e08efa8f6/ws"
+	token := getJwtForDemoUser()
+
+	conn, resp, err := connectWS(t, wsURL, token, "http://localhost:3000")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	defer conn.Close()
+}
+
+func connectWS(t *testing.T, url string, token string, origin string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+
+	dialer := websocket.Dialer{
+		Subprotocols: []string{token},
+	}
+
+	reqHeader := http.Header{}
+	reqHeader.Set("Origin", origin)
+
+	conn, resp, err := dialer.Dial(url, reqHeader)
+
+	return conn, resp, err
+}

--- a/frontend/src/Main/components/Purchase/PollingModal.jsx
+++ b/frontend/src/Main/components/Purchase/PollingModal.jsx
@@ -105,7 +105,8 @@ const PollingModal = ({ show, purchase, onClose, onConfirmed, onComplete }) => {
       }
     };
     const ws = new WebSocket(
-      `${websocketHost}/api/v2/purchases/${purchase.id}/ws?token=${jwtToken}`,
+      `${websocketHost}/api/v2/purchases/${purchase.id}/ws`,
+      [jwtToken],
     );
     wsRef.current = ws;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket connections for purchases now support JWT authentication, enhancing security for real-time updates.

* **Bug Fixes**
  * Improved handling of authentication errors during WebSocket connections, providing clearer unauthorized and forbidden responses.

* **Tests**
  * Added end-to-end tests to verify WebSocket authentication and origin validation for purchase endpoints.

* **Refactor**
  * Updated how JWT tokens are sent during WebSocket connections, now using the subprotocols field instead of URL parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->