### PR TITLE
fix: add timeout mechanism for pending purchases

### DIFF
--- a/frontend/src/Main/Kasseapparat.jsx
+++ b/frontend/src/Main/Kasseapparat.jsx
@@ -160,7 +160,7 @@ const Kasseapparat = () => {
               setOnPollingComplete(() => resolve);
             }),
             new Promise((_, reject) => {
-              const timeoutDuration = 3 * 1000; // 3 minutes timeout
+              const timeoutDuration = 3 * 60 * 1000; // 3 minutes timeout
               setTimeout(
                 () => reject(new Error("Polling timed out")),
                 timeoutDuration,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during checkout by adding a timeout for pending purchases. Users will now see a specific error message if the process takes too long, and the polling modal will always close properly in all cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->