### PR TITLE
fix: websocket connecting mgmt and cleanup, resolves #521

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"log"
 	"os"
+	"time"
 
 	config "github.com/potibm/kasseapparat/internal/app/config"
 	handlerHttp "github.com/potibm/kasseapparat/internal/app/handler/http"
@@ -54,6 +55,7 @@ func main() {
 	router := initializer.InitializeHttpServer(*httpHandler, websocketHandler, *sqliteRepository, staticFiles, jwtMiddleware, cfg)
 
 	startPollerForPendingPurchases(poller, sqliteRepository)
+	startCleanupForWebsocketConnections()
 
 	port := ":3000" // Default port number
 	if len(os.Args) > 1 {
@@ -66,6 +68,10 @@ func main() {
 	if err != nil {
 		panic("[Error] failed to start Gin server due to: " + err.Error())
 	}
+}
+
+func startCleanupForWebsocketConnections() {
+	websocket.StartCleanupRoutine(5 * time.Minute)
 }
 
 func startPollerForPendingPurchases(poller monitor.Poller, sqliteRepository *sqliteRepo.Repository) {

--- a/backend/internal/app/handler/websocket/purchases.go
+++ b/backend/internal/app/handler/websocket/purchases.go
@@ -65,7 +65,11 @@ func (h *Handler) upgradeAndRegister(c *gin.Context) (uuid.UUID, *websocket.Conn
 
 	log.Printf("WebSocket connected for transaction: %s", transactionID)
 
-	registerConnection(transactionID, conn)
+	if !registerConnection(transactionID, conn) {
+		conn.Close()
+
+		return uuid.Nil, nil, false
+	}
 
 	return transactionID, conn, true
 }

--- a/backend/internal/app/handler/websocket/purchases.go
+++ b/backend/internal/app/handler/websocket/purchases.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"log"
 	"net/http"
+	"time"
 
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
@@ -66,6 +67,8 @@ func (h *Handler) upgradeAndRegister(c *gin.Context) (uuid.UUID, *websocket.Conn
 	log.Printf("WebSocket connected for transaction: %s", transactionID)
 
 	if !registerConnection(transactionID, conn) {
+		msg := websocket.FormatCloseMessage(CloseTooManyConnections, "connection limit reached")
+		conn.WriteControl(websocket.CloseMessage, msg, time.Now().Add(time.Second))
 		conn.Close()
 
 		return uuid.Nil, nil, false

--- a/backend/internal/app/handler/websocket/registry.go
+++ b/backend/internal/app/handler/websocket/registry.go
@@ -68,5 +68,12 @@ func sendWSMessage(conn *websocket.Conn, msgType string, data gin.H, transaction
 
 	if err := conn.WriteJSON(payload); err != nil {
 		log.Printf("WebSocket send error [%s]: %v", msgType, err)
+		conn.Close()
+
+		if transactionID != nil {
+			unregisterConnection(*transactionID)
+		}
+
+		return
 	}
 }

--- a/backend/internal/app/handler/websocket/registry.go
+++ b/backend/internal/app/handler/websocket/registry.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"log"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -10,9 +11,12 @@ import (
 	"github.com/potibm/kasseapparat/internal/app/models"
 )
 
+const maxConnections = 100
+
 type wsConnection struct {
-	Conn *websocket.Conn
-	mu   sync.Mutex
+	Conn     *websocket.Conn
+	mu       sync.Mutex
+	lastSeen time.Time
 }
 
 var connections = struct {
@@ -23,11 +27,24 @@ var connections = struct {
 	clients: make(map[string]*wsConnection),
 }
 
-func registerConnection(transactionID uuid.UUID, conn *websocket.Conn) {
+func registerConnection(transactionID uuid.UUID, conn *websocket.Conn) bool {
 	connections.Lock()
 	defer connections.Unlock()
 
-	connections.clients[transactionID.String()] = &wsConnection{Conn: conn}
+	log.Println("Current WebSocket connection number:", len(connections.clients))
+
+	if len(connections.clients) >= maxConnections {
+		log.Printf("WebSocket connection limit reached (%d)", maxConnections)
+
+		return false
+	}
+
+	connections.clients[transactionID.String()] = &wsConnection{
+		Conn:     conn,
+		lastSeen: time.Now(),
+	}
+
+	return true
 }
 
 func unregisterConnection(transactionID uuid.UUID) {
@@ -51,6 +68,7 @@ func PushUpdate(transactionID uuid.UUID, status models.PurchaseStatus) {
 	client.mu.Lock()
 	defer client.mu.Unlock()
 
+	client.lastSeen = time.Now()
 	sendWSMessage(client.Conn, "status_update", gin.H{"status": string(status)}, &transactionID)
 }
 
@@ -75,5 +93,35 @@ func sendWSMessage(conn *websocket.Conn, msgType string, data gin.H, transaction
 		}
 
 		return
+	}
+}
+
+func StartCleanupRoutine(timeout time.Duration) {
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			cleanupStaleConnections(timeout)
+		}
+	}()
+}
+
+func cleanupStaleConnections(timeout time.Duration) {
+	connections.Lock()
+	defer connections.Unlock()
+
+	now := time.Now()
+
+	for id, conn := range connections.clients {
+		conn.mu.Lock()
+		inactive := now.Sub(conn.lastSeen) > timeout
+		conn.mu.Unlock()
+
+		if inactive {
+			log.Printf("Cleaning up stale WebSocket connection: %s", id)
+			conn.Conn.Close()
+			delete(connections.clients, id)
+		}
 	}
 }

--- a/frontend/src/Main/Kasseapparat.jsx
+++ b/frontend/src/Main/Kasseapparat.jsx
@@ -172,13 +172,12 @@ const Kasseapparat = () => {
             return;
           }
         } catch (error) {
+          setPollingModalOpen(false);
           if (error.message === "Polling timed out") {
             showError("Payment processing timed out. Please try again.");
           } else {
             showError("An unexpected error occurred: " + error.message);
           }
-        } finally {
-          setPollingModalOpen(false);
         }
       } else if (createdPurchase.status !== "confirmed") {
         throw new Error(

--- a/frontend/src/Main/Kasseapparat.jsx
+++ b/frontend/src/Main/Kasseapparat.jsx
@@ -151,6 +151,7 @@ const Kasseapparat = () => {
         // open modal and wait
 
         let purchaseSucceeded;
+        let pollingTimeoutTimer;
 
         try {
           purchaseSucceeded = await Promise.race([
@@ -161,10 +162,9 @@ const Kasseapparat = () => {
             }),
             new Promise((_, reject) => {
               const timeoutDuration = 3 * 60 * 1000; // 3 minutes timeout
-              setTimeout(
-                () => reject(new Error("Polling timed out")),
-                timeoutDuration,
-              );
+              pollingTimeoutTimer = setTimeout(() => {
+                reject(new Error("Polling timed out"));
+              }, timeoutDuration);
             }),
           ]);
 
@@ -177,6 +177,10 @@ const Kasseapparat = () => {
             showError("Payment processing timed out. Please try again.");
           } else {
             showError("An unexpected error occurred: " + error.message);
+          }
+        } finally {
+          if (pollingTimeoutTimer) {
+            clearTimeout(pollingTimeoutTimer);
           }
         }
       } else if (createdPurchase.status !== "confirmed") {

--- a/frontend/src/Main/components/Purchase/PollingModal.jsx
+++ b/frontend/src/Main/components/Purchase/PollingModal.jsx
@@ -17,6 +17,7 @@ const PollingModal = ({ show, purchase, onClose, onConfirmed, onComplete }) => {
   const wsRef = useRef(null);
   const { token: jwtToken } = useAuth();
   const { websocketHost } = useConfig();
+  const connectionRef = useRef(false);
 
   const sumUpReaderId = getCurrentReaderId();
   const closeModalTimeout = 3000;
@@ -81,6 +82,9 @@ const PollingModal = ({ show, purchase, onClose, onConfirmed, onComplete }) => {
   };
 
   useEffect(() => {
+    if (connectionRef.current) return;
+    connectionRef.current = true;
+
     const handleFailure = (message) => {
       wasHandledRef.current = true;
       setStatus("failed");
@@ -152,8 +156,8 @@ const PollingModal = ({ show, purchase, onClose, onConfirmed, onComplete }) => {
       setError("WebSocket error occurred");
     };
 
-    ws.onclose = () => {
-      console.log("WebSocket closed");
+    ws.onclose = (event) => {
+      console.log("WebSocket closed", event);
       if (!wasHandledRef.current && statusRef.current === "pending") {
         handleFailure("Connection lost.");
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automatic periodic cleanup of inactive WebSocket connections to improve reliability.
  * Enforced a maximum limit of 100 simultaneous WebSocket connections.
  * Enhanced connection management with automatic removal and closure of stale or unresponsive connections.
  * Added logging for connection counts, limit breaches, and cleanup actions.

* **Bug Fixes**
  * Improved handling of failed WebSocket connection registrations, ensuring unregistered connections are immediately closed.

* **Improvements**
  * Prevented multiple WebSocket connections from being established simultaneously in the purchase polling component.
  * Enhanced WebSocket closure logging for better diagnostics.
  * Ensured proper clearing of polling timeouts to avoid lingering timers after completion or errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->