### PR TITLE
fix: do not close sumup modal

### DIFF
--- a/frontend/src/Main/components/Purchase/PollingModal.jsx
+++ b/frontend/src/Main/components/Purchase/PollingModal.jsx
@@ -91,7 +91,6 @@ const PollingModal = ({ show, purchase, onClose, onConfirmed, onComplete }) => {
       setError(message);
       setProcessing(false);
       onComplete(false);
-      setTimeout(onClose, closeModalTimeout);
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
         wsRef.current.close();
       }
@@ -205,16 +204,17 @@ const PollingModal = ({ show, purchase, onClose, onConfirmed, onComplete }) => {
         </div>
       </ModalBody>
       <ModalFooter>
-        {status === "pending" && (
-          <MyButton
-            color="failure"
-            disabled={processing}
-            onClick={() => cancelPayment()}
-          >
-            {processing ? "Cancelling..." : "Abort Purchase"}
-            {processing && <Spinner color="gray" className="ml-2" />}
-          </MyButton>
-        )}
+        <div className="w-full flex justify-center">
+          {status === "pending" && (
+            <MyButton disabled={processing} onClick={() => cancelPayment()}>
+              {processing ? "Cancelling..." : "Abort Purchase"}
+              {processing && <Spinner color="gray" className="ml-2" />}
+            </MyButton>
+          )}
+          {status === "failed" && (
+            <MyButton onClick={() => onClose()}>Close</MyButton>
+          )}
+        </div>
       </ModalFooter>
     </Modal>
   );


### PR DESCRIPTION
first (small) optimization after Evoke: will not close the modal, so that a user clearly sees an error message. except for successful transaction. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed purchases now show a Close button to dismiss the modal.
* **Bug Fixes**
  * The modal no longer auto-closes on failure, preventing unexpected dismissal and allowing users to review the error.
* **Style**
  * Footer content is centered for a cleaner look.
  * The Abort Purchase button appears only while a purchase is pending.
  * Abort button retains clear states (disabled during processing, “Cancelling…” label, and spinner) with improved layout for better visibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->